### PR TITLE
Add support for .NET Framework 4.5 projects

### DIFF
--- a/src/Serilog.Sinks.Kafka/Serilog.Sinks.Kafka.csproj
+++ b/src/Serilog.Sinks.Kafka/Serilog.Sinks.Kafka.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <PackageId>Serilog.Sinks.Confluent.Kafka</PackageId>
     <Title>Serilog.Sinks.Confluent.Kafka</Title>
     <Authors>Jon Hoare</Authors>
-    <Description>Serilog event sink that writes to Kafka endpoints, using Confluent.Kafka, including Azure Event Hubs. This sink works with Serilog Version >2.8.0</Description>
-    <PackageDescription>Serilog event sink that writes to Kafka endpoints, using Confluent.Kafka, including Azure Event Hubs. This sink works with Serilog Version >2.8.0</PackageDescription>
+    <Description>Serilog event sink that writes to Kafka endpoints, using Confluent.Kafka, including Azure Event Hubs. This sink works with Serilog Version &gt;2.8.0</Description>
+    <PackageDescription>Serilog event sink that writes to Kafka endpoints, using Confluent.Kafka, including Azure Event Hubs. This sink works with Serilog Version &gt;2.8.0</PackageDescription>
     <RepositoryUrl>https://github.com/jonhoare/serilog-sinks-kafka</RepositoryUrl>
     <PackageIconUrl>http://serilog.net/images/serilog-sink-nuget.png</PackageIconUrl>
     <Tags>seilog logging azure kafka</Tags>


### PR DESCRIPTION
I've got some legacy code that would benefit from this sink, and simply adding the target framework enables that to happen.  

If you don't want this in the main package I can always just take a fork and create a private package that includes this.  But I'm thinking it's probably a good and easy thing to add for at least the current version of the package and if support needs to be dropped in a later version that would be fine.