### PR TITLE
Feature failure callback

### DIFF
--- a/src/Serilog.Sinks.Kafka/EmitEventFailureHandling.cs
+++ b/src/Serilog.Sinks.Kafka/EmitEventFailureHandling.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Serilog.Sinks.Kafka
+{
+    /// <summary>
+    /// Sepecifies options for handling failures when emitting the events to Elasticsearch. Can be a combination of options.
+    /// </summary>
+    [Flags]
+    public enum EmitEventFailureHandling
+    {
+        /// <summary>
+        /// Send the error to the SelfLog
+        /// </summary>
+        WriteToSelfLog = 1,
+
+        /// <summary>
+        /// Write the events to another sink. Make sure to configure this one.
+        /// </summary>
+        WriteToFailureSink = 2,
+
+        /// <summary>
+        /// Throw the exception to the caller.
+        /// </summary>
+        ThrowException = 4,
+
+        /// <summary>
+        /// The failure callback function will be called when the event cannot be submitted to Elasticsearch.
+        /// </summary>
+        RaiseCallback = 8
+    }
+}

--- a/src/Serilog.Sinks.Kafka/KafkaSink.cs
+++ b/src/Serilog.Sinks.Kafka/KafkaSink.cs
@@ -1,6 +1,4 @@
 ﻿using Confluent.Kafka;
-using Serilog.Configuration;
-using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.PeriodicBatching;
@@ -102,78 +100,6 @@ namespace Serilog.Sinks.Kafka
 
             producer = new ProducerBuilder<Null, byte[]>(config)
                 .Build();
-        }
-    }
-
-    public static class LoggerConfigurationKafkaExtensions
-    {
-        /// <summary>
-        /// Adds a sink that writes log events to a Kafka topic in the broker endpoints.
-        /// </summary>
-        /// <param name="loggerConfiguration">The logger configuration.</param>
-        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
-        /// <param name="period">The time in seconds to wait between checking for event batches.</param>
-        /// <param name="bootstrapServers">The list of bootstrapServers separated by comma.</param>
-        /// <param name="topic">The topic name.</param>
-        /// <returns></returns>
-        public static LoggerConfiguration Kafka(
-            this LoggerSinkConfiguration loggerConfiguration,
-            string bootstrapServers = "localhost:9092",
-            int batchSizeLimit = 50,
-            int period = 5,
-            SecurityProtocol securityProtocol = SecurityProtocol.Plaintext,
-            SaslMechanism saslMechanism = SaslMechanism.Plain,
-            string topic = "logs",
-            string saslUsername = null,
-            string saslPassword = null,
-            string sslCaLocation = null,
-            ITextFormatter formatter = null,
-            LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            var sink = new KafkaSink(
-                bootstrapServers,
-                batchSizeLimit,
-                period,
-                securityProtocol,
-                saslMechanism,
-                topic,
-                saslUsername,
-                saslPassword,
-                sslCaLocation,
-                formatter);
-
-            return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
-        }
-
-        public static LoggerConfiguration Kafka(
-            this LoggerSinkConfiguration loggerConfiguration,
-            Func<LogEvent, string> topicDecider,
-            string bootstrapServers = "localhost:9092",
-            int batchSizeLimit = 50,
-            int period = 5,
-            SecurityProtocol securityProtocol = SecurityProtocol.Plaintext,
-            SaslMechanism saslMechanism = SaslMechanism.Plain,
-            string saslUsername = null,
-            string saslPassword = null,
-            string sslCaLocation = null,
-            ITextFormatter formatter = null,
-            LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
-            LoggingLevelSwitch levelSwitch = null)
-        {
-            var sink = new KafkaSink(
-                bootstrapServers,
-                batchSizeLimit,
-                period,
-                securityProtocol,
-                saslMechanism,
-                topicDecider,
-                saslUsername,
-                saslPassword,
-                sslCaLocation,
-                formatter);
-
-            return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
         }
     }
 }

--- a/src/Serilog.Sinks.Kafka/KafkaSink.cs
+++ b/src/Serilog.Sinks.Kafka/KafkaSink.cs
@@ -1,5 +1,6 @@
 ﻿using Confluent.Kafka;
 using Serilog.Configuration;
+using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.PeriodicBatching;
@@ -32,7 +33,7 @@ namespace Serilog.Sinks.Kafka
             string sslCaLocation,
             ITextFormatter formatter = null) : base(batchSizeLimit, TimeSpan.FromSeconds(period))
         {
-            ConfigureKafkaConnection(bootstrapServers, securityProtocol, saslMechanism, saslUsername, 
+            ConfigureKafkaConnection(bootstrapServers, securityProtocol, saslMechanism, saslUsername,
                 saslPassword, sslCaLocation);
 
             this.formatter = formatter ?? new Formatting.Json.JsonFormatter(renderMessage: true);
@@ -125,8 +126,10 @@ namespace Serilog.Sinks.Kafka
             string topic = "logs",
             string saslUsername = null,
             string saslPassword = null,
-            string sslCaLocation = null, 
-            ITextFormatter formatter = null)
+            string sslCaLocation = null,
+            ITextFormatter formatter = null,
+            LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
+            LoggingLevelSwitch levelSwitch = null)
         {
             var sink = new KafkaSink(
                 bootstrapServers,
@@ -137,10 +140,10 @@ namespace Serilog.Sinks.Kafka
                 topic,
                 saslUsername,
                 saslPassword,
-                sslCaLocation, 
+                sslCaLocation,
                 formatter);
 
-            return loggerConfiguration.Sink(sink);
+            return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
         }
 
         public static LoggerConfiguration Kafka(
@@ -154,7 +157,9 @@ namespace Serilog.Sinks.Kafka
             string saslUsername = null,
             string saslPassword = null,
             string sslCaLocation = null,
-            ITextFormatter formatter = null)
+            ITextFormatter formatter = null,
+            LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
+            LoggingLevelSwitch levelSwitch = null)
         {
             var sink = new KafkaSink(
                 bootstrapServers,
@@ -168,7 +173,7 @@ namespace Serilog.Sinks.Kafka
                 sslCaLocation,
                 formatter);
 
-            return loggerConfiguration.Sink(sink);
+            return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
         }
     }
 }

--- a/src/Serilog.Sinks.Kafka/KafkaSinkOptions.cs
+++ b/src/Serilog.Sinks.Kafka/KafkaSinkOptions.cs
@@ -1,0 +1,40 @@
+﻿using Confluent.Kafka;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+using System;
+
+namespace Serilog.Sinks.Kafka
+{
+    public class KafkaSinkOptions
+    {
+        public string BootstrapServers { get; set; }
+        public int BatchSizeLimit { get; set; }
+        public int Period { get; set; }
+        public SecurityProtocol SecurityProtocol { get; set; }
+        public SaslMechanism SaslMechanism { get; set; }
+        public string Topic { get; set; }
+        public string SaslUsername { get; set; }
+        public string SaslPassword { get; set; }
+        public string SslCaLocation { get; set; }
+        public ITextFormatter Formatter { get; set; } = null;
+        public Func<LogEvent, string> TopicDecider { get; set; } = null;
+
+        /// <summary>
+        /// Specifies how failing emits should be handled.
+        /// </summary>
+        public EmitEventFailureHandling EmitEventFailure { get; set; }
+
+        /// <summary>
+        /// Sink to use when kafka is unable to accept the events. This is optional and depends on the EmitEventFailure setting.
+        /// </summary>
+        public ILogEventSink FailureSink { get; set; }
+
+        /// <summary>
+        /// A callback which can be used to handle logevents which are not submitted to kafka
+        /// like when it is unable to accept the events. This is optional and depends on the EmitEventFailure setting.
+        /// </summary>
+        public Action<LogEvent> FailureCallback { get; set; }
+
+    }
+}

--- a/src/Serilog.Sinks.Kafka/KafkaSinkOptions.cs
+++ b/src/Serilog.Sinks.Kafka/KafkaSinkOptions.cs
@@ -8,15 +8,15 @@ namespace Serilog.Sinks.Kafka
 {
     public class KafkaSinkOptions
     {
-        public string BootstrapServers { get; set; }
-        public int BatchSizeLimit { get; set; }
-        public int Period { get; set; }
-        public SecurityProtocol SecurityProtocol { get; set; }
-        public SaslMechanism SaslMechanism { get; set; }
-        public string Topic { get; set; }
-        public string SaslUsername { get; set; }
-        public string SaslPassword { get; set; }
-        public string SslCaLocation { get; set; }
+        public string BootstrapServers { get; set; } = "localhost:9092";
+        public int BatchSizeLimit { get; set; } = 50;
+        public int Period { get; set; } = 5;
+        public SecurityProtocol SecurityProtocol { get; set; } = SecurityProtocol.Plaintext;
+        public SaslMechanism SaslMechanism { get; set; } = SaslMechanism.Plain;
+        public string Topic { get; set; } = "logs";
+        public string SaslUsername { get; set; } = null;
+        public string SaslPassword { get; set; } = null;
+        public string SslCaLocation { get; set; } = null;
         public ITextFormatter Formatter { get; set; } = null;
         public Func<LogEvent, string> TopicDecider { get; set; } = null;
 

--- a/src/Serilog.Sinks.Kafka/LoggerConfigurationKafkaExtensions.cs
+++ b/src/Serilog.Sinks.Kafka/LoggerConfigurationKafkaExtensions.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using Confluent.Kafka;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Sinks.Kafka
+{
+    public static class LoggerConfigurationKafkaExtensions
+    {
+        /// <summary>
+        /// Adds a sink that writes log events to a Kafka topic in the broker endpoints.
+        /// </summary>
+        /// <param name="loggerConfiguration">The logger configuration.</param>
+        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
+        /// <param name="period">The time in seconds to wait between checking for event batches.</param>
+        /// <param name="bootstrapServers">The list of bootstrapServers separated by comma.</param>
+        /// <param name="topic">The topic name.</param>
+        /// <returns></returns>
+        public static LoggerConfiguration Kafka(
+            this LoggerSinkConfiguration loggerConfiguration,
+            string bootstrapServers = "localhost:9092",
+            int batchSizeLimit = 50,
+            int period = 5,
+            SecurityProtocol securityProtocol = SecurityProtocol.Plaintext,
+            SaslMechanism saslMechanism = SaslMechanism.Plain,
+            string topic = "logs",
+            string saslUsername = null,
+            string saslPassword = null,
+            string sslCaLocation = null,
+            ITextFormatter formatter = null,
+            LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            var sink = new KafkaSink(
+                bootstrapServers,
+                batchSizeLimit,
+                period,
+                securityProtocol,
+                saslMechanism,
+                topic,
+                saslUsername,
+                saslPassword,
+                sslCaLocation,
+                formatter);
+
+            return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
+        }
+
+        public static LoggerConfiguration Kafka(
+            this LoggerSinkConfiguration loggerConfiguration,
+            Func<LogEvent, string> topicDecider,
+            string bootstrapServers = "localhost:9092",
+            int batchSizeLimit = 50,
+            int period = 5,
+            SecurityProtocol securityProtocol = SecurityProtocol.Plaintext,
+            SaslMechanism saslMechanism = SaslMechanism.Plain,
+            string saslUsername = null,
+            string saslPassword = null,
+            string sslCaLocation = null,
+            ITextFormatter formatter = null,
+            LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            var sink = new KafkaSink(
+                bootstrapServers,
+                batchSizeLimit,
+                period,
+                securityProtocol,
+                saslMechanism,
+                topicDecider,
+                saslUsername,
+                saslPassword,
+                sslCaLocation,
+                formatter);
+
+            return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
+        }
+    }
+}

--- a/src/Serilog.Sinks.Kafka/LoggerConfigurationKafkaExtensions.cs
+++ b/src/Serilog.Sinks.Kafka/LoggerConfigurationKafkaExtensions.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using Confluent.Kafka;
+﻿using Confluent.Kafka;
 using Serilog.Configuration;
 using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting;
+using System;
 
 namespace Serilog.Sinks.Kafka
 {
@@ -74,6 +74,16 @@ namespace Serilog.Sinks.Kafka
                 saslPassword,
                 sslCaLocation,
                 formatter);
+
+            return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
+        }
+
+        public static LoggerConfiguration Kafka(
+            this LoggerSinkConfiguration loggerConfiguration,
+           KafkaSinkOptions options, LogEventLevel restrictedToMinLevel = LogEventLevel.Verbose,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            var sink = new KafkaSink(options);
 
             return loggerConfiguration.Sink(sink, restrictedToMinLevel, levelSwitch);
         }


### PR DESCRIPTION
In order to handle exceptions when it is not possible to send logs to Kafka, FailureCallback method implemented.